### PR TITLE
Fixes map overlap bug on visualization switch

### DIFF
--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -37,6 +37,7 @@ const MapPage = () => {
   const router = useRouter();
   const pathname = usePathname();
 
+  const [loadingMap, setLoadingMap] = useState<boolean>(false);
   const [imageData, setImageData] = useState<IMapInfo>({
     name: "",
     year: "",
@@ -103,7 +104,11 @@ const MapPage = () => {
   return (
     <MapTemplate>
       <MapContainer>
-        <MapTiff data={imageData} onClick={handleMapClick} />
+        <MapTiff
+          data={imageData}
+          onClick={handleMapClick}
+          setLoading={setLoadingMap}
+        />
       </MapContainer>
       <MapDescription
         imageInfo={descriptionInfo}
@@ -113,6 +118,7 @@ const MapPage = () => {
       <HeaderWrapper>
         <MenuWrapper>
           <MapsMenu
+            isLoading={loadingMap}
             initialValues={imageData}
             options={Object.values(EEImages)}
             retracted={isMenuRetracted}

--- a/src/components/DateInput/DateInput.styles.tsx
+++ b/src/components/DateInput/DateInput.styles.tsx
@@ -121,7 +121,7 @@ export const RangeInput = styled.input`
     background: ${({ theme }) => theme.colors.black};
   }
 
-  &[type="range"]:disabled {
+  &:disabled {
     cursor: not-allowed;
   }
 `;

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -14,9 +14,11 @@ import {
 const DateInput = ({
   mapId,
   dates,
+  isLoading,
   onChange,
 }: {
   mapId: string;
+  isLoading: boolean;
   initialYear?: string;
   dates: IImageData;
   onChange: (newValues: IMapInfo) => void;
@@ -49,7 +51,7 @@ const DateInput = ({
   }, [mapId]);
 
   return (
-    <Wrapper disabled={("general" in dates).toString()}>
+    <Wrapper disabled={("general" in dates || isLoading).toString()}>
       <CalendarImage
         src={calendarIcon}
         alt={calendarIcon}
@@ -59,7 +61,7 @@ const DateInput = ({
       <DateInfo>{dates?.general ? "--" : currentDate}</DateInfo>
       <InputWrapper>
         <RangeInput
-          disabled={"general" in dates}
+          disabled={"general" in dates || isLoading}
           type="range"
           ref={inputRef}
           min={1}

--- a/src/components/MapTiff/MapTiff.tsx
+++ b/src/components/MapTiff/MapTiff.tsx
@@ -11,9 +11,11 @@ const HOST_URL = process.env.NEXT_PUBLIC_HOST_URL;
 const MapTiff = ({
   data,
   onClick,
+  setLoading,
   ...props
 }: {
   data: IMapInfo;
+  setLoading: (e: any) => void;
   onClick?: (e: any) => void;
 }) => {
   const { name, year } = data;
@@ -42,18 +44,23 @@ const MapTiff = ({
 
   const loadLayer = useCallback(
     async (name: string, year: string) => {
+      setLoading(true);
       if (!map?.getSource(name + year)) {
         const response = await fetch(
           `${HOST_URL}/api/ee?name=${name}&year=${year}`,
         );
-        const { url } = await response.json();
 
-        if (!map?.getSource(name + year)) {
-          map?.addSource(name + year, {
-            type: "raster",
-            tiles: [url],
-            tileSize: 256,
-          });
+        if (response.status !== 200) {
+          setLoading(false);
+        } else {
+          const { url } = await response.json();
+          if (!map?.getSource(name + year)) {
+            map?.addSource(name + year, {
+              type: "raster",
+              tiles: [url],
+              tileSize: 256,
+            });
+          }
         }
       }
 
@@ -74,8 +81,9 @@ const MapTiff = ({
         },
         firstSymbolId,
       );
+      setLoading(false);
     },
-    [map],
+    [map, setLoading],
   );
 
   useEffect(() => {

--- a/src/components/MapsMenu/MapsMenu.tsx
+++ b/src/components/MapsMenu/MapsMenu.tsx
@@ -16,6 +16,7 @@ const MapsMenu = ({
   initialValues,
   options,
   retracted,
+  isLoading,
   setRetracted,
   onSelectChange,
   onQuestionSelect,
@@ -23,6 +24,7 @@ const MapsMenu = ({
   initialValues: IMapInfo;
   options: IEEInfo[];
   retracted: boolean;
+  isLoading: boolean;
   setRetracted: (retracted: boolean) => void;
   onSelectChange: (newValues: IMapInfo) => void;
   onQuestionSelect: (newItem: string, retract?: boolean) => void;
@@ -70,6 +72,7 @@ const MapsMenu = ({
               <ItemWrapper key={item.id}>
                 <VisuItem
                   info={item}
+                  isLoading={isLoading}
                   onClick={onQuestionSelect}
                   onChange={onItemChange}
                 />
@@ -89,6 +92,7 @@ const MapsMenu = ({
           mapId={currentName}
           initialYear={initialValues?.year}
           dates={currentImagedata}
+          isLoading={isLoading}
           onChange={onSelectChange}
         />
       </ContentWrapper>

--- a/src/components/VisuItem/VisuItem.styles.tsx
+++ b/src/components/VisuItem/VisuItem.styles.tsx
@@ -22,6 +22,12 @@ export const ItemWrapper = styled.div`
 export const Input = styled.input`
   cursor: pointer;
 
+  &:disabled,
+  &:disabled ~ label {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
   &[type="radio"] {
     transition: 0.3s;
     -webkit-appearance: none;

--- a/src/components/VisuItem/VisuItem.tsx
+++ b/src/components/VisuItem/VisuItem.tsx
@@ -4,10 +4,12 @@ import { capitalize } from "@/utils/functions";
 
 export const VisuItem = ({
   info,
+  isLoading,
   onChange,
   onClick,
 }: {
   info: IVisuMenuItems;
+  isLoading: boolean;
   onChange: (newValue: string) => void;
   onClick: (newValue: string, retract: boolean) => void;
 }) => {
@@ -21,6 +23,7 @@ export const VisuItem = ({
         name={name}
         checked={checked}
         value={id}
+        disabled={isLoading}
         onChange={() => onChange(id)}
         onClick={() => onClick(id, false)}
       />


### PR DESCRIPTION
## Description

This PR fixes the bug that appears on switch not loaded visualizations. Before this, the visualization would overlap each other. Here we added a loading state that disables the inputs on the menu maps form.

## How to test it

You'll only need to enter /map and then play with the maps menu.