### PR TITLE
Changes back ModalMenu position to middle screen on smaller screen 

### DIFF
--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -17,6 +17,7 @@ import {
   MenuWrapper,
   NameContainer,
   QuestionImage,
+  QuestionWrapper,
   VisuName,
 } from "./styles";
 import Link from "next/link";
@@ -127,7 +128,7 @@ const MapPage = () => {
         {imageData.name && (
           <NameContainer>
             <VisuName>{capitalize(EEImages[imageData.name]?.name)}</VisuName>
-            <div onClick={() => handleDescUpdate(imageData.name)}>
+            <QuestionWrapper onClick={() => handleDescUpdate(imageData.name)}>
               <QuestionImage
                 title={`Sobre ${EEImages[imageData.name]?.name}`}
                 src={QuestionIcon}
@@ -135,7 +136,7 @@ const MapPage = () => {
                 height={20}
                 width={20}
               />
-            </div>
+            </QuestionWrapper>
           </NameContainer>
         )}
       </HeaderWrapper>

--- a/src/app/map/styles.tsx
+++ b/src/app/map/styles.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 export const MapContainer = styled.div`
   width: 100vw;
-  height: 100vh;
+  height: 100svh;
   position: absolute;
   box-sizing: border-box;
   left: 0;
@@ -45,17 +45,29 @@ export const NameContainer = styled.div`
   gap: 1rem;
   z-index: 1;
 
+  max-width: 18rem;
   border-radius: 4px;
   padding: 0.25rem 1rem;
   align-items: center;
   background-color: ${({ theme }) => theme.colors.white};
   box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
   border-radius: 4px;
+
+  @media screen and (max-width: 400px) {
+    max-width: 14rem;
+  }
 `;
 
 export const VisuName = styled.h1`
-  font-size: 1.1rem;
+  font-size: 1rem;
   font-weight: bold;
+`;
+
+export const QuestionWrapper = styled.div`
+  width: fit-content;
+  height: 100%;
+  display: flex;
+  align-items: center;
 `;
 export const QuestionImage = styled(Image)`
   transition: 0.2s;
@@ -68,5 +80,5 @@ export const QuestionImage = styled(Image)`
 
 export const MapLegendContainer = styled.div`
   margin: auto 0 0 auto;
-  z-index: 2;
+  z-index: 0;
 `;

--- a/src/components/MapDescription/MapDescription.styles.ts
+++ b/src/components/MapDescription/MapDescription.styles.ts
@@ -21,8 +21,4 @@ export const Description = styled.p`
   margin-top: 0.5rem;
   overflow-y: scroll;
   max-height: 12rem;
-
-  @media screen and (max-width: 750px) and (max-height: 800px) {
-    max-height: 5rem;
-  }
 `;

--- a/src/components/MapLegend/MapLegend.styles.tsx
+++ b/src/components/MapLegend/MapLegend.styles.tsx
@@ -12,7 +12,7 @@ export const Wrapper = styled.div`
   gap: 1rem;
   box-sizing: border-box;
   padding: 0.75rem;
-  z-index: 10;
+  z-index: 4;
 `;
 
 export const HeaderContainer = styled.div`

--- a/src/components/MenuModal/MenuModal.styles.tsx
+++ b/src/components/MenuModal/MenuModal.styles.tsx
@@ -82,25 +82,9 @@ export const ModalWrapper = styled.div<{ retracted: string; position: string }>`
       ? "translateX(-110%)"
       : "translateX(110%)";
 
-    const transformSmallExpanded = "translateX(-50%)";
-    const transformSmallRetracted = isLeft
-      ? "translateX(-50rem)"
-      : "translateX(50rem)";
-
     return `
       ${isLeft ? "left: 0;" : "right: 0;"}
       transform: ${retracted === "true" ? transformRetracted : transformExpanded};
-
-      @media screen and (max-width: 750px) {
-        left: 50%;
-        margin: 0 0;
-        ${isLeft ? "top: 9%;" : "top: 57%;"}
-        transform: ${retracted === "true" ? transformSmallRetracted : transformSmallExpanded};
-      }
-
-      @media screen and (max-width: 750px) and (max-height: 800px) {
-        ${isLeft ? "top: 9%;" : "top: 68%;"}
-      }        
     `;
   }}
 `;


### PR DESCRIPTION
## Description
Changes the previous positions of the MenuModal to overlapping in the middle for smaller screens.
![image](https://github.com/OCA-UFCG/oca-frontend/assets/42751604/8c083220-f67b-402c-abb4-71add687be22)

## How to test it.
In smaller screens play with the Maps menu modal and the description modal