### PR TITLE
Download Tiffs

### DIFF
--- a/public/sprite.svg
+++ b/public/sprite.svg
@@ -480,9 +480,11 @@
         </symbol>
 
         <symbol viewBox="0 0 14 14" id="expand" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M10 1H13V3.99996" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"
+            <path d="M10 1H13V3.99996" stroke="currentColor" stroke-width="1.25"
+                stroke-linecap="round"
                 stroke-linejoin="round" />
-            <path d="M3.99996 13H1V10" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"
+            <path d="M3.99996 13H1V10" stroke="currentColor" stroke-width="1.25"
+                stroke-linecap="round"
                 stroke-linejoin="round" />
         </symbol>
 
@@ -588,6 +590,18 @@
                     <rect width="20" height="20" fill="white" transform="translate(0.25 0.669434)" />
                 </clipPath>
             </defs>
+        </symbol>
+
+        <symbol viewBox="0 0 15 16" id="download" fill="none"
+            xmlns="http://www.w3.org/2000/svg">
+            <path
+                d="M1 11.833V13.4997C1 13.9417 1.17559 14.3656 1.48816 14.6782C1.80072 14.9907 2.22464 15.1663 2.66667 15.1663H12.6667C13.1087 15.1663 13.5326 14.9907 13.8452 14.6782C14.1577 14.3656 14.3333 13.9417 14.3333 13.4997V11.833"
+                stroke="currentColor" stroke-width="1.25" stroke-linecap="round"
+                stroke-linejoin="round" />
+            <path d="M3.5 6.83301L7.66667 10.9997L11.8333 6.83301" stroke="currentColor"
+                stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M7.6665 1V11" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"
+                stroke-linejoin="round" />
         </symbol>
 
 

--- a/src/components/DownloadSelector/DownloadSelector.styles.tsx
+++ b/src/components/DownloadSelector/DownloadSelector.styles.tsx
@@ -1,0 +1,35 @@
+import styled from "styled-components";
+import { Icon } from "../Icon/Icon";
+
+export const DownloadSelectorWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+export const YearSelect = styled.select`
+  border-radius: 4px;
+  background-color: ${({ theme }) => theme.colors.white};
+  border: none;
+  padding: 0.5rem;
+  font-size: 1rem;
+  width: 5rem;
+  cursor: pointer;
+  text-align-last: center;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+`;
+
+export const QuestionMarkImg = styled(Icon)`
+  max-width: 1rem;
+  height: fit-content;
+  transition: 300ms;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.6;
+    transform: scale(0.97);
+  }
+`;

--- a/src/components/DownloadSelector/DownloadSelector.tsx
+++ b/src/components/DownloadSelector/DownloadSelector.tsx
@@ -1,0 +1,61 @@
+import { IFormItem } from "@/utils/interfaces";
+import {
+  YearSelect,
+  DownloadSelectorWrapper,
+  QuestionMarkImg,
+} from "./DownloadSelector.styles";
+import { useEffect, useState } from "react";
+
+const DownloadSelector = ({ item }: { item: IFormItem }) => {
+  const convertToDownloadLink = (item: IFormItem, year?: string) => {
+    const imageData = item.imageData;
+    const tifInfo = imageData[year || item.year || "general"];
+    const driveUrl = tifInfo.linkDrive;
+    const regex = /\/d\/([a-zA-Z0-9_-]+)/;
+    const match = driveUrl?.match(regex);
+
+    if (match && match[1]) {
+      const fileId = match[1];
+
+      return `https://drive.google.com/uc?export=download&id=${fileId}`;
+    }
+
+    return "";
+  };
+
+  const [currentYear, setCurrentYear] = useState<string>(item.year);
+  const [downloadLink, setDownloadLink] = useState<string>(
+    convertToDownloadLink(item, currentYear),
+  );
+
+  useEffect(() => {
+    setDownloadLink(convertToDownloadLink(item, currentYear));
+  }, [currentYear, item]);
+
+  return (
+    <DownloadSelectorWrapper>
+      <a target="_blank" href={downloadLink} title={`Baixar ${item.name}`}>
+        <QuestionMarkImg id="download" height={20} width={20} />
+      </a>
+      <YearSelect
+        value={currentYear}
+        onChange={(e) => setCurrentYear(e.target.value)}
+        disabled={currentYear == "general"}
+      >
+        {currentYear == "general" ? (
+          <option value="general" disabled={true} selected={true}>
+            --
+          </option>
+        ) : (
+          Object.keys(item.imageData).map((year) => (
+            <option key={year} value={year}>
+              {year}
+            </option>
+          ))
+        )}
+      </YearSelect>
+    </DownloadSelectorWrapper>
+  );
+};
+
+export default DownloadSelector;

--- a/src/components/MapsMenu/MapsMenu.styles.tsx
+++ b/src/components/MapsMenu/MapsMenu.styles.tsx
@@ -68,3 +68,13 @@ export const NoDataElement = styled.div<{ delay: number }>`
   width: 100%;
   border-radius: 4px;
 `;
+
+export const YearSelect = styled.select`
+  border-radius: 4px;
+  background-color: ${({ theme }) => theme.colors.white};
+  border: none;
+  padding: 0.5rem;
+  font-size: 1rem;
+  width: 8rem;
+  cursor: pointer;
+`;

--- a/src/components/MapsMenu/MapsMenu.tsx
+++ b/src/components/MapsMenu/MapsMenu.tsx
@@ -12,8 +12,8 @@ import {
   NoDataElement,
   QuestionMarkImg,
   Title,
-  YearSelect,
 } from "./MapsMenu.styles";
+import DownloadSelector from "../DownloadSelector/DownloadSelector";
 
 const MapsMenu = ({
   initialValues,
@@ -38,22 +38,6 @@ const MapsMenu = ({
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-
-  const convertToDownloadLink = (item: IFormItem) => {
-    const imageData = item.imageData;
-    const tifInfo = imageData[item.year || "general"];
-    const driveUrl = tifInfo.linkDrive;
-    const regex = /\/d\/([a-zA-Z0-9_-]+)/;
-    const match = driveUrl?.match(regex);
-
-    if (match && match[1]) {
-      const fileId = match[1];
-
-      return `https://drive.google.com/uc?export=download&id=${fileId}`;
-    }
-
-    return "";
-  };
 
   const getYears = (imageData: IImageData) => {
     return Object.keys(imageData).sort((a, b) => {
@@ -136,33 +120,7 @@ const MapsMenu = ({
                     >
                       <QuestionMarkImg id="question" height={20} width={20} />
                     </div>
-                    <a
-                      target="_blank"
-                      href={convertToDownloadLink(item)}
-                      title={`Baixar ${item.name}`}
-                    >
-                      <QuestionMarkImg id="download" height={20} width={20} />
-                    </a>
-                    <YearSelect
-                      onChange={(e) => (item.year = e.target.value)}
-                      disabled={item.year == "general"}
-                    >
-                      {item.year == "general" ? (
-                        <option
-                          value="general"
-                          disabled={true}
-                          selected={item.year == "general"}
-                        >
-                          --
-                        </option>
-                      ) : (
-                        getYears(item.imageData).map((year) => (
-                          <option key={year} value={year}>
-                            {year}
-                          </option>
-                        ))
-                      )}
-                    </YearSelect>
+                    <DownloadSelector item={item} />
                   </ItemWrapper>
                 );
               })}

--- a/src/components/MapsMenu/MapsMenu.tsx
+++ b/src/components/MapsMenu/MapsMenu.tsx
@@ -12,6 +12,7 @@ import {
   NoDataElement,
   QuestionMarkImg,
   Title,
+  YearSelect,
 } from "./MapsMenu.styles";
 
 const MapsMenu = ({
@@ -37,6 +38,31 @@ const MapsMenu = ({
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+
+  const convertToDownloadLink = (item: IFormItem) => {
+    const imageData = item.imageData;
+    const tifInfo = imageData[item.year || "general"];
+    const driveUrl = tifInfo.linkDrive;
+    const regex = /\/d\/([a-zA-Z0-9_-]+)/;
+    const match = driveUrl?.match(regex);
+
+    if (match && match[1]) {
+      const fileId = match[1];
+
+      return `https://drive.google.com/uc?export=download&id=${fileId}`;
+    }
+
+    return "";
+  };
+
+  const getYears = (imageData: IImageData) => {
+    return Object.keys(imageData).sort((a, b) => {
+      if (a === "general") return -1;
+      if (b === "general") return 1;
+
+      return a.localeCompare(b);
+    });
+  };
 
   const handleVisuChange = useCallback(
     (newImageData: IMapInfo) => {
@@ -68,6 +94,7 @@ const MapsMenu = ({
           name: item.name,
           checked: item.id === newValue,
           imageData: item.imageData,
+          year: getYears(item.imageData)[0],
         };
       }),
     );
@@ -109,6 +136,33 @@ const MapsMenu = ({
                     >
                       <QuestionMarkImg id="question" height={20} width={20} />
                     </div>
+                    <a
+                      target="_blank"
+                      href={convertToDownloadLink(item)}
+                      title={`Baixar ${item.name}`}
+                    >
+                      <QuestionMarkImg id="download" height={20} width={20} />
+                    </a>
+                    <YearSelect
+                      onChange={(e) => (item.year = e.target.value)}
+                      disabled={item.year == "general"}
+                    >
+                      {item.year == "general" ? (
+                        <option
+                          value="general"
+                          disabled={true}
+                          selected={item.year == "general"}
+                        >
+                          --
+                        </option>
+                      ) : (
+                        getYears(item.imageData).map((year) => (
+                          <option key={year} value={year}>
+                            {year}
+                          </option>
+                        ))
+                      )}
+                    </YearSelect>
                   </ItemWrapper>
                 );
               })}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -85,6 +85,7 @@ export const defaultEEInfo: IEEInfo = {
         { color: "#white", label: "" },
         { color: "#black", label: "" },
       ],
+      linkDrive: "",
     },
   },
   measurementUnit: "classes",

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -77,6 +77,7 @@ export interface IEEInfo {
       default: boolean;
       imageId: string;
       imageParams: IImageParam[];
+      linkDrive: string;
     };
   };
 }
@@ -97,6 +98,7 @@ export interface IFormItem {
   name: string;
   checked: boolean;
   imageData: IImageData;
+  year: string;
 }
 
 export interface IImageData {
@@ -107,6 +109,7 @@ export interface IImageProps {
   default?: boolean;
   imageId: string;
   pallete?: string[];
+  linkDrive?: string;
 }
 
 export interface INews {


### PR DESCRIPTION
This PR implements a feature to download tiffs of map images. It is possible to download tifs by pressing the download button now present in the view selection on the map page, and you can also select the year in which the download will take place