### PR TITLE
change the map title to follow the CMS format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ docker-build-dev:
 	docker build -t $(IMAGE_NAME) .
 
 docker-run-dev:
-	docker run -p 3000:$(CONTAINER_PORT) --name $(IMAGE_NAME) -v node_modules -v $(PWD):/app $(IMAGE_NAME)
+	docker run -p 3000:$(CONTAINER_PORT) --name $(IMAGE_NAME) -v node_modules -v $(PWD):/app --user $(id -u):$(id -g) $(IMAGE_NAME)
 
 docker-build-prod:
 	docker build \

--- a/src/components/MapsSection/MapsSection.tsx
+++ b/src/components/MapsSection/MapsSection.tsx
@@ -18,7 +18,6 @@ import {
 } from "./MapsSection.styles";
 import { useEffect, useState } from "react";
 import { IEEInfo, ISectionHeader } from "@/utils/interfaces";
-import { capitalize } from "@/utils/functions";
 import { defaultEEInfo } from "@/utils/constants";
 import { Icon } from "../Icon/Icon";
 import { SectionHeader } from "../SectionHeader/SectionHeader";
@@ -106,7 +105,7 @@ const MapsSection = ({
               >
                 <VisuHeader>
                   <VisuName active={(tag.id === currentVisu.id).toString()}>
-                    {capitalize(tag.name)}
+                    {tag.name}
                   </VisuName>
                   <IconWrapper>
                     <VisuIcon

--- a/src/components/VisuItem/VisuItem.tsx
+++ b/src/components/VisuItem/VisuItem.tsx
@@ -1,6 +1,5 @@
 import { IVisuMenuItems } from "@/utils/interfaces";
 import { Input, ItemWrapper, Label } from "./VisuItem.styles";
-import { capitalize } from "@/utils/functions";
 
 export const VisuItem = ({
   info,
@@ -27,7 +26,7 @@ export const VisuItem = ({
         onChange={() => onChange(id)}
         onClick={() => onClick(id, false)}
       />
-      <Label htmlFor={id}>{capitalize(name)}</Label>
+      <Label htmlFor={id}>{name}</Label>
     </ItemWrapper>
   );
 };


### PR DESCRIPTION
This PR changes the map title, removing the case sensitive format to follow the CMS format, this update has been applied to both the homepage and the '/map' route