### PR TITLE
fix: changing the cursor style (hover) in maps & visu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ docker-build-dev:
 	docker build -t $(IMAGE_NAME) .
 
 docker-run-dev:
-	docker run -p 3000:$(CONTAINER_PORT) --name $(IMAGE_NAME) -v node_modules -v $(PWD):/app $(IMAGE_NAME)
+	docker run -p 3000:$(CONTAINER_PORT) --name $(IMAGE_NAME) -v node_modules -v $(PWD):/app --user $(id -u):$(id -g) $(IMAGE_NAME)
 
 docker-build-prod:
 	docker build \

--- a/src/components/MapsSection/MapsSection.styles.tsx
+++ b/src/components/MapsSection/MapsSection.styles.tsx
@@ -77,6 +77,8 @@ export const TagButton = styled.span<{ active?: string }>`
   box-sizing: border-box;
   background-color: #ffffff95;
 
+  cursor: ${({ active }) => active !== "true" && "pointer"};
+
   &:hover {
     transform: scale(${({ active }) => active !== "true" && "0.99"});
     color: ${({ theme }) => theme.colors.green};

--- a/src/components/MapsSection/MapsSection.styles.tsx
+++ b/src/components/MapsSection/MapsSection.styles.tsx
@@ -77,8 +77,6 @@ export const TagButton = styled.span<{ active?: string }>`
   box-sizing: border-box;
   background-color: #ffffff95;
 
-  cursor: ${({ active }) => (active === "true" ? "not-allowed" : "pointer")};
-
   &:hover {
     transform: scale(${({ active }) => active !== "true" && "0.99"});
     color: ${({ theme }) => theme.colors.green};


### PR DESCRIPTION
This PR modifies the cursor style when hovering the description of the maps in the maps & visu section. Before, when hovering, the cursor style would be "not-allowed". Now, the style is default ("text").