### PR TITLE
Adds category divisions on maps menu 

### DIFF
--- a/public/sprite.svg
+++ b/public/sprite.svg
@@ -530,9 +530,9 @@
         </symbol>
 
         <symbol viewBox="0 0 20 20" id="close" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M15 5L5 15" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"
+            <path d="M15 5L5 15" stroke="currentColor" stroke-linecap="round"
                 stroke-linejoin="round" />
-            <path d="M5 5L15 15" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"
+            <path d="M5 5L15 15" stroke="currentColor" stroke-linecap="round"
                 stroke-linejoin="round" />
         </symbol>
 

--- a/src/app/globalStyles.tsx
+++ b/src/app/globalStyles.tsx
@@ -140,7 +140,7 @@ export const GlobalStyles = createGlobalStyle`
     font-size: 100%;
     font: inherit;
     vertical-align: baseline;
-    color: ${({ theme }) => theme.colors.black}
+    color: ${({ theme }) => theme.colors["dark-gray"]}
   }
 
   /* HTML5 display-role reset for older browsers */

--- a/src/app/globalStyles.tsx
+++ b/src/app/globalStyles.tsx
@@ -17,13 +17,13 @@ export const GlobalStyles = createGlobalStyle`
 
     ::-webkit-scrollbar {
       height: 0.5rem;
-      width: 0.5rem;
+      width: 0.25rem;
       padding: 10px;
     }
     
     ::-webkit-scrollbar-thumb {
       background: ${({ theme }) => theme.colors.green}75;
-      scroll-padding: 1rem;
+      scroll-padding: 0.2rem;
       background-clip: padding-box;
     }
 

--- a/src/app/theme.ts
+++ b/src/app/theme.ts
@@ -8,6 +8,7 @@ declare module "styled-components" {
     maroon: string;
     white: string;
     black: string;
+    "dark-gray": string;
     gray: string;
     orange: string;
     yellow: string;
@@ -27,6 +28,7 @@ export const theme: DefaultTheme = {
     maroon: "#8f4456",
     white: "white",
     black: "#1e1e1e",
+    "dark-gray": "#444444",
     gray: "#858585",
     orange: "#AA633B",
     yellow: "#CEA15B",

--- a/src/components/MapsMenu/MapsMenu.styles.tsx
+++ b/src/components/MapsMenu/MapsMenu.styles.tsx
@@ -68,3 +68,11 @@ export const NoDataElement = styled.div<{ delay: number }>`
   width: 100%;
   border-radius: 4px;
 `;
+
+export const SubSectionWrapper = styled.div`
+  display: flex;
+  flex-flow: column;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 1rem 0;
+`;

--- a/src/components/MapsMenu/MapsMenu.styles.tsx
+++ b/src/components/MapsMenu/MapsMenu.styles.tsx
@@ -7,28 +7,27 @@ export const ContentWrapper = styled.div`
   align-items: center;
 `;
 
-export const Title = styled.h3`
-  font-weight: bold;
-  font-size: 1.1rem;
-
-  &::before,
-  &::after {
-    content: " - ";
-  }
-`;
-
 export const Form = styled.form`
   display: flex;
   flex-flow: column;
-  gap: 0.5rem;
-  width: 100%;
-  padding: 1.5rem 0 1rem 0;
+  box-sizing: border-box;
+  width: 20rem;
+  height: 100vh;
+  padding-right: 0.3rem;
+
+  max-height: 24rem;
+  overflow-y: scroll;
+  overflow-x: hidden;
 `;
 
 export const ItemWrapper = styled.div`
   display: flex;
   gap: 1rem;
   align-items: center;
+`;
+
+export const InfoContainer = styled.div`
+  margin-right: 0.45rem;
 `;
 
 export const QuestionMarkImg = styled(Icon)`
@@ -74,14 +73,40 @@ export const SubSectionWrapper = styled.div`
   flex-flow: column;
   gap: 0.5rem;
   width: 100%;
-  padding: 1rem 0;
+  transition: 100ms;
+  margin-top: 0;
+`;
+
+export const IconWrapper = styled(Icon)`
+  color: ${({ theme }) => theme.colors.black};
+  transition: 100ms linear;
 `;
 
 export const FieldDetails = styled.details`
+  box-sizing: border-box;
   display: flex;
   gap: 0.5rem;
   width: 100%;
   padding: 0.5rem 0;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.green}40;
+  color: ${({ theme }) => theme.colors.green};
+
+  &:not([open]) ${IconWrapper} {
+    transform: rotate(45deg);
+  }
+
+  &[open] ${SubSectionWrapper} {
+    margin-top: 1rem;
+  }
+
+  &:not([open]) ${SubSectionWrapper} {
+    margin-top: 0rem;
+  }
+`;
+
+export const Title = styled.h3`
+  font-weight: bold;
+  transition: 300ms;
 `;
 
 export const Summary = styled.summary`
@@ -91,13 +116,17 @@ export const Summary = styled.summary`
   width: 100%;
   font-weight: bold;
   cursor: pointer;
-  color: ${({ theme }) => theme.colors["dark-gray"]};
-`;
+  border-radius: 4px;
+  padding: 0.5rem;
+  box-sizing: border-box;
+  margin-left: 1px;
+  transition: 300ms;
 
-export const IconWrapper = styled(Icon)`
-  color: ${({ theme }) => theme.colors.black};
+  &:hover {
+    background: #cdcdcd20;
+  }
 
-  &.spin {
-    animation: spin 1.5s linear infinite;
+  &:hover ${Title}, &:hover ${IconWrapper} {
+    color: ${({ theme }) => theme.colors.green};
   }
 `;

--- a/src/components/MapsMenu/MapsMenu.styles.tsx
+++ b/src/components/MapsMenu/MapsMenu.styles.tsx
@@ -76,3 +76,28 @@ export const SubSectionWrapper = styled.div`
   width: 100%;
   padding: 1rem 0;
 `;
+
+export const FieldDetails = styled.details`
+  display: flex;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 0;
+`;
+
+export const Summary = styled.summary`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  font-weight: bold;
+  cursor: pointer;
+  color: ${({ theme }) => theme.colors["dark-gray"]};
+`;
+
+export const IconWrapper = styled(Icon)`
+  color: ${({ theme }) => theme.colors.black};
+
+  &.spin {
+    animation: spin 1.5s linear infinite;
+  }
+`;

--- a/src/components/MapsMenu/MapsMenu.tsx
+++ b/src/components/MapsMenu/MapsMenu.tsx
@@ -12,6 +12,7 @@ import {
   NoDataElement,
   QuestionMarkImg,
   Title,
+  SubSectionWrapper,
 } from "./MapsMenu.styles";
 
 const MapsMenu = ({
@@ -32,6 +33,7 @@ const MapsMenu = ({
   onQuestionSelect: (newItem: string, retract?: boolean) => void;
 }) => {
   const [formValues, setFormValues] = useState<IFormItem[]>([]);
+  const [mapTypes, setMapTypes] = useState<{ [key: string]: IFormItem[] }>({});
   const [currentImagedata, setcurrentImageData] = useState<IImageData>({});
   const [currentName, setCurrentName] = useState<string>("");
   const router = useRouter();
@@ -68,14 +70,26 @@ const MapsMenu = ({
           name: item.name,
           checked: item.id === newValue,
           imageData: item.imageData,
+          type: item.type,
         };
       }),
     );
+
+    const typesMap: { [key: string]: IFormItem[] } = {};
+
+    formValues.forEach((item) => {
+      if (!typesMap[item.type]) {
+        typesMap[item.type] = [];
+      }
+
+      typesMap[item.type].push(item);
+    });
+
+    setMapTypes(typesMap);
   };
 
   useEffect(() => {
     onItemChange(initialValues.name);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialValues]);
 
   return (
@@ -90,28 +104,41 @@ const MapsMenu = ({
         <Title>Visualizações Disponíveis</Title>
         {formValues.length > 0 ? (
           <Form>
-            {formValues
-              .sort((element1, element2) =>
-                element1.name.localeCompare(element2.name),
-              )
-              .map((item: IFormItem) => {
-                return (
-                  <ItemWrapper key={item.id}>
-                    <VisuItem
-                      info={item}
-                      isLoading={isLoading}
-                      onClick={onQuestionSelect}
-                      onChange={onItemChange}
-                    />
-                    <div
-                      onClick={() => onQuestionSelect(item.id)}
-                      title={`Sobre ${item.name}`}
-                    >
-                      <QuestionMarkImg id="question" height={20} width={20} />
-                    </div>
-                  </ItemWrapper>
-                );
-              })}
+            {Object.keys(mapTypes)
+              .sort((a, b) => b.localeCompare(a))
+              .map((type) => (
+                <fieldset key={type}>
+                  <legend>{type}</legend>
+                  <SubSectionWrapper>
+                    {mapTypes[type]
+                      .sort((element1, element2) =>
+                        element1.name.localeCompare(element2.name),
+                      )
+                      .map((item: IFormItem) => {
+                        return (
+                          <ItemWrapper key={item.id}>
+                            <VisuItem
+                              info={item}
+                              isLoading={isLoading}
+                              onClick={onQuestionSelect}
+                              onChange={onItemChange}
+                            />
+                            <div
+                              onClick={() => onQuestionSelect(item.id)}
+                              title={`Sobre ${item.name}`}
+                            >
+                              <QuestionMarkImg
+                                id="question"
+                                height={20}
+                                width={20}
+                              />
+                            </div>
+                          </ItemWrapper>
+                        );
+                      })}
+                  </SubSectionWrapper>
+                </fieldset>
+              ))}
           </Form>
         ) : (
           <NoDataContainer>

--- a/src/components/MapsMenu/MapsMenu.tsx
+++ b/src/components/MapsMenu/MapsMenu.tsx
@@ -11,8 +11,10 @@ import {
   NoDataContainer,
   NoDataElement,
   QuestionMarkImg,
-  Title,
   SubSectionWrapper,
+  FieldDetails,
+  Summary,
+  IconWrapper,
 } from "./MapsMenu.styles";
 
 const MapsMenu = ({
@@ -101,14 +103,16 @@ const MapsMenu = ({
       setRetracted={setRetracted}
     >
       <ContentWrapper>
-        <Title>Visualizações Disponíveis</Title>
         {formValues.length > 0 ? (
           <Form>
             {Object.keys(mapTypes)
               .sort((a, b) => b.localeCompare(a))
               .map((type) => (
-                <fieldset key={type}>
-                  <legend>{type}</legend>
+                <FieldDetails key={type}>
+                  <Summary>
+                    <h4>{type}</h4>
+                    <IconWrapper id="close" size={16} stroke-width={3} />
+                  </Summary>
                   <SubSectionWrapper>
                     {mapTypes[type]
                       .sort((element1, element2) =>
@@ -137,7 +141,7 @@ const MapsMenu = ({
                         );
                       })}
                   </SubSectionWrapper>
-                </fieldset>
+                </FieldDetails>
               ))}
           </Form>
         ) : (

--- a/src/components/MapsMenu/MapsMenu.tsx
+++ b/src/components/MapsMenu/MapsMenu.tsx
@@ -15,6 +15,8 @@ import {
   FieldDetails,
   Summary,
   IconWrapper,
+  InfoContainer,
+  Title,
 } from "./MapsMenu.styles";
 
 const MapsMenu = ({
@@ -38,6 +40,7 @@ const MapsMenu = ({
   const [mapTypes, setMapTypes] = useState<{ [key: string]: IFormItem[] }>({});
   const [currentImagedata, setcurrentImageData] = useState<IImageData>({});
   const [currentName, setCurrentName] = useState<string>("");
+  const [currentCategory, setCurrentCategory] = useState<string>("");
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -65,6 +68,7 @@ const MapsMenu = ({
         if (item.id === newValue) {
           setCurrentName(item.id);
           setcurrentImageData(item.imageData);
+          currentCategory === "" && setCurrentCategory(item.type);
         }
 
         return {
@@ -92,6 +96,7 @@ const MapsMenu = ({
 
   useEffect(() => {
     onItemChange(initialValues.name);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialValues]);
 
   return (
@@ -108,10 +113,10 @@ const MapsMenu = ({
             {Object.keys(mapTypes)
               .sort((a, b) => b.localeCompare(a))
               .map((type) => (
-                <FieldDetails key={type}>
+                <FieldDetails key={type} open={currentCategory === type}>
                   <Summary>
-                    <h4>{type}</h4>
-                    <IconWrapper id="close" size={16} stroke-width={3} />
+                    <Title>{type}</Title>
+                    <IconWrapper id="close" size={16} stroke-width={2} />
                   </Summary>
                   <SubSectionWrapper>
                     {mapTypes[type]
@@ -127,7 +132,7 @@ const MapsMenu = ({
                               onClick={onQuestionSelect}
                               onChange={onItemChange}
                             />
-                            <div
+                            <InfoContainer
                               onClick={() => onQuestionSelect(item.id)}
                               title={`Sobre ${item.name}`}
                             >
@@ -136,7 +141,7 @@ const MapsMenu = ({
                                 height={20}
                                 width={20}
                               />
-                            </div>
+                            </InfoContainer>
                           </ItemWrapper>
                         );
                       })}

--- a/src/components/VisuItem/VisuItem.styles.tsx
+++ b/src/components/VisuItem/VisuItem.styles.tsx
@@ -14,8 +14,6 @@ export const ItemWrapper = styled.div`
   gap: 0.5rem;
   width: 100%;
   padding: 0.5rem 1rem 0.5rem 0.5rem;
-  background-color: ${({ theme }) => theme.colors.white};
-  box-shadow: 0px 0px 2px #e0e0e0;
   border-radius: 4px;
 `;
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -91,6 +91,7 @@ export const defaultEEInfo: IEEInfo = {
   poster: "/defaultMapsPoster.png",
   minScale: 0,
   maxScale: 1,
+  type: "default",
 };
 
 export const defaultNews: INews[] = [

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -97,6 +97,7 @@ export interface IEEInfo {
       imageParams: IImageParam[];
     };
   };
+  type: string;
 }
 
 export interface IMapId {
@@ -115,6 +116,7 @@ export interface IFormItem {
   name: string;
   checked: boolean;
   imageData: IImageData;
+  type: string;
 }
 
 export interface IImageData {


### PR DESCRIPTION
## Description

This PR creates a new category division for the maps visualizations on the maps menu

## How to test it

You'll only need to run it and access the `/maps` route and see if it works properly. The menu should initiate with the current visualization category open.