### PR TITLE
fix: fixed layers superposition (map page and maps and visu sections)

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
This PR fixed the superposition in the map's layers.

## How to test it
1. go to map/
2. change the visu options of the map (specially "indice de aridez": choose "2010" then change to "ìndice de degradação". It would be preferable if the page already started at the "Índice de Aridez" option)

## How it should behave
1. the map's layers should not superpose. 