### PR TITLE
fixes pixel value at smaller zooms

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/app/api/ee/route.ts
+++ b/src/app/api/ee/route.ts
@@ -15,6 +15,7 @@ export async function POST(req: NextRequest) {
     const { imageId, imageParams } = imageInfo.imageData[year];
 
     let image = ee.Image(imageId).selfMask();
+    image = image.reduceResolution(ee.Reducer.mode(), true, 128);
 
     const filteredImageParams = imageParams.filter(
       (imageParam) => imageParam.pixelLimit,


### PR DESCRIPTION
Modify the Pyramiding Policy so that they do not generalize the pixel value in a smaller zoom based on the mean, but rather on the mode