### PR TITLE
Feat: CI/CD AWS

### DIFF
--- a/.github/workflows/deploy-oca.yml
+++ b/.github/workflows/deploy-oca.yml
@@ -5,12 +5,12 @@ on:
     tags: ["*"]
 
 jobs:
-  build:
+  build-primaria:
     runs-on: oca-self-hosted-runner
     steps:
       - uses: actions/checkout@v4
 
-      - name: Update docker metadata with the tag 
+      - name: Update docker metadata with the tag
         uses: docker/metadata-action@v4
         id: meta
         with:
@@ -47,13 +47,72 @@ jobs:
             NEXT_PUBLIC_MAIL_APP_PASS=${{ secrets.NEXT_PUBLIC_MAIL_APP_PASS }}
 
       - name: Pull the latest image
-        run: sudo docker pull ${{ vars.DOCKER_IMAGE_PROD }}:latest    
-      
+        run: sudo docker pull ${{ vars.DOCKER_IMAGE_PROD }}:latest
+
       - name: Stop existing container
-        run: sudo docker rm -f ${{ vars.CONTAINER_NAME_PROD }} || true 
-         
+        run: sudo docker rm -f ${{ vars.CONTAINER_NAME_PROD }} || true
+
       - name: Run new container
         run: sudo docker run --name ${{ vars.CONTAINER_NAME_PROD }} -p ${{ vars.HOST_PORT_PROD }}:${{ vars.CONTAINER_PORT }} -d ${{ vars.DOCKER_IMAGE_PROD }}:latest
+
+      - name: Add network
+        run: docker network connect oca-network oca-frontend-app
+
+      - name: Prune unused Docker images
+        run: sudo docker system prune -f
+
+  build-failover:
+    runs-on: oca-self-hosted-runner
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update docker metadata with the tag
+        uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: ${{ vars.DOCKER_IMAGE_PROD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          file: Dockerfile.production
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ vars.DOCKER_IMAGE_PROD }}:latest
+            ${{ steps.meta.outputs.tags }}
+          build-args: |
+            NEXT_PUBLIC_HOST_URL=${{ vars.NEXT_PUBLIC_HOST_URL }}
+            NEXT_PUBLIC_GEE_PRIVATE_KEY=${{ secrets.NEXT_PUBLIC_GEE_PRIVATE_KEY }}
+            NEXT_PUBLIC_GA_ID=${{ secrets.NEXT_PUBLIC_GA_ID }}
+            NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN=${{ secrets.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN }}
+            NEXT_PUBLIC_CONTENTFUL_SPACE=${{ secrets.NEXT_PUBLIC_CONTENTFUL_SPACE  }}
+            NEXT_PUBLIC_MAIL_APP_TO=${{ vars.NEXT_PUBLIC_MAIL_APP_TO }}
+            NEXT_PUBLIC_MAIL_APP_CC=${{ vars.NEXT_PUBLIC_MAIL_APP_CC }}
+            NEXT_PUBLIC_MAIL_APP_USER=${{ vars.NEXT_PUBLIC_MAIL_APP_USER }}
+            NEXT_PUBLIC_MAIL_APP_PASS=${{ secrets.NEXT_PUBLIC_MAIL_APP_PASS }}
+
+      - name: Pull the latest image
+        run: sudo docker pull ${{ vars.DOCKER_IMAGE_PROD }}:latest
+
+      - name: Stop existing container
+        run: sudo docker rm -f ${{ vars.CONTAINER_NAME_PROD }} || true
+
+      - name: Run new container
+        run: sudo docker run --name ${{ vars.CONTAINER_NAME_PROD }} -p ${{ vars.HOST_PORT_PROD }}:${{ vars.CONTAINER_PORT }} -d ${{ vars.DOCKER_IMAGE_PROD }}:latest
+
+      - name: Add network
+        run: docker network connect oca-network oca-frontend-app
 
       - name: Prune unused Docker images
         run: sudo docker system prune -f

--- a/.github/workflows/deploy-oca.yml
+++ b/.github/workflows/deploy-oca.yml
@@ -109,7 +109,7 @@ jobs:
         run: sudo docker rm -f ${{ vars.CONTAINER_NAME_PROD }} || true
 
       - name: Run new container
-        run: sudo docker run --name ${{ vars.CONTAINER_NAME_PROD }} -p ${{ vars.HOST_PORT_PROD }}:${{ vars.CONTAINER_PORT }} -d ${{ vars.DOCKER_IMAGE_PROD }}:latest
+        run: sudo docker run --restart unless-stopped --name ${{ vars.CONTAINER_NAME_PROD }} -p ${{ vars.HOST_PORT_PROD }}:${{ vars.CONTAINER_PORT }} -d ${{ vars.DOCKER_IMAGE_PROD }}:latest
 
       - name: Add network
         run: docker network connect oca-network oca-frontend-app

--- a/.github/workflows/deploy-oca.yml
+++ b/.github/workflows/deploy-oca.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-primaria:
-    runs-on: oca-self-hosted-runner
+    runs-on: x1-aws-self-hosted-runner
     steps:
       - uses: actions/checkout@v4
 
@@ -62,7 +62,7 @@ jobs:
         run: sudo docker system prune -f
 
   build-failover:
-    runs-on: oca-self-hosted-runner
+    runs-on: x2-aws-self-hosted-runner
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy-oca.yml
+++ b/.github/workflows/deploy-oca.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Run new container
         run: sudo docker run --restart unless-stopped --name ${{ vars.CONTAINER_NAME_PROD }} -p ${{ vars.HOST_PORT_PROD }}:${{ vars.CONTAINER_PORT }} -d ${{ vars.DOCKER_IMAGE_PROD }}:latest
 
-      - name: Add network
+      - name: Connect to oca network
         run: docker network connect oca-network oca-frontend-app
 
       - name: Prune unused Docker images

--- a/.github/workflows/deploy-oca.yml
+++ b/.github/workflows/deploy-oca.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Run new container
         run: sudo docker run --name ${{ vars.CONTAINER_NAME_PROD }} -p ${{ vars.HOST_PORT_PROD }}:${{ vars.CONTAINER_PORT }} -d ${{ vars.DOCKER_IMAGE_PROD }}:latest
 
-      - name: Add network
+      - name: Connect to oca-network
         run: docker network connect oca-network oca-frontend-app
 
       - name: Prune unused Docker images

--- a/.github/workflows/deploy-oca.yml
+++ b/.github/workflows/deploy-oca.yml
@@ -5,8 +5,8 @@ on:
     tags: ["*"]
 
 jobs:
-  build-primaria:
-    runs-on: x1-aws-self-hosted-runner
+  primary-build:
+    runs-on: primary-self-hosted-runner
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy-oca.yml
+++ b/.github/workflows/deploy-oca.yml
@@ -53,7 +53,7 @@ jobs:
         run: sudo docker rm -f ${{ vars.CONTAINER_NAME_PROD }} || true
 
       - name: Run new container
-        run: sudo docker run --name ${{ vars.CONTAINER_NAME_PROD }} -p ${{ vars.HOST_PORT_PROD }}:${{ vars.CONTAINER_PORT }} -d ${{ vars.DOCKER_IMAGE_PROD }}:latest
+        run: sudo docker run --restart unless-stopped --name ${{ vars.CONTAINER_NAME_PROD }} -p ${{ vars.HOST_PORT_PROD }}:${{ vars.CONTAINER_PORT }} -d ${{ vars.DOCKER_IMAGE_PROD }}:latest
 
       - name: Connect to oca-network
         run: docker network connect oca-network oca-frontend-app

--- a/.github/workflows/deploy-oca.yml
+++ b/.github/workflows/deploy-oca.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Prune unused Docker images
         run: sudo docker system prune -f
 
-  build-failover:
-    runs-on: x2-aws-self-hosted-runner
+  secondary-build:
+    runs-on: secondary-self-hosted-runner
     steps:
       - uses: actions/checkout@v4
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
This PR adds a new CI/CD to the 2 AWS EC2 instances.
It automates the build and deploy in those instances, more specifically the deploy for production. 

# How to test it
This feat can be tested when a new tag is added to the repository, then it triggers GitHub Action which creates jobs and the automation starts.

## Changes
The changes were made in: .github/workflows/deploy-oca-yml