### PR TITLE
Feat/perguntas frequentes section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,7 @@ export default async function Home() {
     sponsors,
     tiffInfo,
     sectionHead,
+    FAQ,
   } = await getContent([
     "news",
     "publications",
@@ -45,7 +46,7 @@ export default async function Home() {
         publications={publications}
       />
       <SponsorsSection sponsors={sponsors} sectionHead={sectionHead} />
-      <FAQSection sectionHead={sectionHead} FAQ={publications} />
+      <FAQSection sectionHead={sectionHead} FAQ={FAQ} />
     </Template>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { getContent } from "@/utils/functions";
 import AboutHomeSection from "@/components/AboutHomeSection/AboutHomeSection";
 import { MapTiffProvider } from "@/contexts/MapContext";
 import { Suspense } from "react";
+import FAQSection from "@/components/FAQSection/FAQSection";
 
 export const revalidate = 60;
 
@@ -23,6 +24,7 @@ export default async function Home() {
     "sponsors",
     "tiffInfo",
     "about",
+    "FAQ",
     "sectionHead",
   ]);
 
@@ -43,6 +45,7 @@ export default async function Home() {
         publications={publications}
       />
       <SponsorsSection sponsors={sponsors} sectionHead={sectionHead} />
+      <FAQSection sectionHead={sectionHead} FAQ={publications}></FAQSection>
     </Template>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,7 +45,7 @@ export default async function Home() {
         publications={publications}
       />
       <SponsorsSection sponsors={sponsors} sectionHead={sectionHead} />
-      <FAQSection sectionHead={sectionHead} FAQ={publications}></FAQSection>
+      <FAQSection sectionHead={sectionHead} FAQ={publications} />
     </Template>
   );
 }

--- a/src/components/FAQSection/FAQSection.styles.tsx
+++ b/src/components/FAQSection/FAQSection.styles.tsx
@@ -11,5 +11,5 @@ export const FAQContainer = styled.div`
   flex-flow: column;
   align-items: center;
   width: 100%;
-  gap: 0.5rem;
+  gap: 1rem;
 `;

--- a/src/components/FAQSection/FAQSection.styles.tsx
+++ b/src/components/FAQSection/FAQSection.styles.tsx
@@ -1,0 +1,13 @@
+import { Section } from "@/app/globalStyles";
+import styled from "styled-components";
+
+export const Wrapper = styled(Section)`
+  margin: 2rem 0;
+`;
+
+export const FAQContainer = styled.div`
+  display: flex;
+  flex-flow: column;
+  align-items: center;
+  width: 100%;
+`;

--- a/src/components/FAQSection/FAQSection.styles.tsx
+++ b/src/components/FAQSection/FAQSection.styles.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Section } from "@/app/globalStyles";
 import styled from "styled-components";
 
@@ -10,4 +11,5 @@ export const FAQContainer = styled.div`
   flex-flow: column;
   align-items: center;
   width: 100%;
+  gap: 0.5rem;
 `;

--- a/src/components/FAQSection/FAQSection.tsx
+++ b/src/components/FAQSection/FAQSection.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { IPublication, ISectionHeader } from "@/utils/interfaces";
 import { FAQContainer, Wrapper } from "./FAQSection.styles";
 import { SectionHeader } from "../SectionHeader/SectionHeader";

--- a/src/components/FAQSection/FAQSection.tsx
+++ b/src/components/FAQSection/FAQSection.tsx
@@ -16,10 +16,7 @@ const FAQSection = ({
       <SectionHeader id="FAQ" sectionHead={sectionHead} />
       <FAQContainer>
         {FAQ.map((publications, index) => (
-          <QuestionFAQ
-            key={index}
-            data={publications.fields as unknown as IPublication}
-          />
+          <QuestionFAQ key={index} data={publications.fields} />
         ))}
       </FAQContainer>
     </Wrapper>

--- a/src/components/FAQSection/FAQSection.tsx
+++ b/src/components/FAQSection/FAQSection.tsx
@@ -1,0 +1,29 @@
+"use client";
+import { IPublication, ISectionHeader } from "@/utils/interfaces";
+import { FAQContainer, Wrapper } from "./FAQSection.styles";
+import { SectionHeader } from "../SectionHeader/SectionHeader";
+import QuestionFAQ from "./QuestionFAQ/QuestionFAQ";
+
+const FAQSection = ({
+  sectionHead,
+  FAQ,
+}: {
+  sectionHead: ISectionHeader[];
+  FAQ: { fields: IPublication }[];
+}) => {
+  return (
+    <Wrapper full={"false"} id="FAQ">
+      <SectionHeader id="FAQ" sectionHead={sectionHead} />
+      <FAQContainer>
+        {FAQ.map((publications, index) => (
+          <QuestionFAQ
+            key={index}
+            data={publications.fields as unknown as IPublication}
+          />
+        ))}
+      </FAQContainer>
+    </Wrapper>
+  );
+};
+
+export default FAQSection;

--- a/src/components/FAQSection/FAQSection.tsx
+++ b/src/components/FAQSection/FAQSection.tsx
@@ -1,4 +1,4 @@
-import { IPublication, ISectionHeader } from "@/utils/interfaces";
+import { IFAQ, ISectionHeader } from "@/utils/interfaces";
 import { FAQContainer, Wrapper } from "./FAQSection.styles";
 import { SectionHeader } from "../SectionHeader/SectionHeader";
 import QuestionFAQ from "./QuestionFAQ/QuestionFAQ";
@@ -8,14 +8,14 @@ const FAQSection = ({
   FAQ,
 }: {
   sectionHead: ISectionHeader[];
-  FAQ: { fields: IPublication }[];
+  FAQ: { fields: IFAQ }[];
 }) => {
   return (
     <Wrapper full={"false"} id="FAQ">
       <SectionHeader id="FAQ" sectionHead={sectionHead} />
       <FAQContainer>
-        {FAQ.map((publications, index) => (
-          <QuestionFAQ key={index} data={publications.fields} />
+        {FAQ.map((FAQ, index) => (
+          <QuestionFAQ key={index} data={FAQ.fields} />
         ))}
       </FAQContainer>
     </Wrapper>

--- a/src/components/FAQSection/QuestionFAQ/QuestionFAQ.styles.tsx
+++ b/src/components/FAQSection/QuestionFAQ/QuestionFAQ.styles.tsx
@@ -3,12 +3,30 @@ import { Icon } from "@/components/Icon/Icon";
 import styled from "styled-components";
 
 export const SubSectionFAQ = styled.p`
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
   transition: 100ms;
   padding: 0.5rem 1rem 1rem;
-  margin: 0;
+  margin: 1rem;
+
+  h2 {
+    font-size: 1.7rem;
+    margin: 1rem 0;
+  }
+
+  h3,
+  h4 {
+    font-weight: bold;
+    font-size: 1.2rem;
+    margin: 1rem 0;
+  }
+
+  strong {
+    font-weight: bold;
+  }
+
+  ul {
+    margin: 1rem 0;
+    padding-left: 1.5rem;
+  }
 `;
 
 export const IconWrapper = styled(Icon)`

--- a/src/components/FAQSection/QuestionFAQ/QuestionFAQ.styles.tsx
+++ b/src/components/FAQSection/QuestionFAQ/QuestionFAQ.styles.tsx
@@ -7,7 +7,7 @@ export const SubSectionFAQ = styled.p`
   align-items: center;
   gap: 0.5rem;
   transition: 100ms;
-  padding: 0 1rem;
+  padding: 0.5rem 1rem 1rem;
   margin: 0;
 `;
 
@@ -29,9 +29,9 @@ export const Summary = styled.summary`
 
 export const QuestionContainer = styled.details`
   display: flex;
+  flex-flow: column;
   width: 100%;
-  padding: 1rem 0;
-  margin: 1rem;
+  max-width: 60rem;
   background-color: white;
 
   box-shadow: 0px 0px 2px grey;
@@ -42,10 +42,6 @@ export const QuestionContainer = styled.details`
 
   summary:hover {
     background: #cdcdcd20;
-  }
-
-  @media (min-width: 768px) {
-    width: 50%;
   }
 `;
 

--- a/src/components/FAQSection/QuestionFAQ/QuestionFAQ.styles.tsx
+++ b/src/components/FAQSection/QuestionFAQ/QuestionFAQ.styles.tsx
@@ -1,20 +1,30 @@
+"use client";
 import { Icon } from "@/components/Icon/Icon";
 import styled from "styled-components";
 
-export const SubSectionFAQ = styled.div`
+export const SubSectionFAQ = styled.p`
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding-left: 0.5rem;
   transition: 100ms;
-  margin-top: 0;
-  margin-left: 0.5rem;
+  padding: 0 1rem;
+  margin: 0;
 `;
 
 export const IconWrapper = styled(Icon)`
   color: ${({ theme }) => theme.colors.black};
   transition: 100ms linear;
   flex-shrink: 0;
+`;
+
+export const Summary = styled.summary`
+  display: flex;
+  justify-content: space-between;
+  font-weight: bold;
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 1rem;
+  align-items: center;
 `;
 
 export const QuestionContainer = styled.details`
@@ -30,8 +40,8 @@ export const QuestionContainer = styled.details`
     transform: rotate(45deg);
   }
 
-  &[open] ${SubSectionFAQ} {
-    margin-top: 0.5rem;
+  summary:hover {
+    background: #cdcdcd20;
   }
 
   @media (min-width: 768px) {
@@ -41,22 +51,6 @@ export const QuestionContainer = styled.details`
 
 export const Title = styled.h3`
   word-break: break-word;
-  padding: 0.25rem;
-`;
-
-export const Summary = styled.summary`
-  display: flex;
-  justify-content: space-between;
-  font-weight: bold;
-  cursor: pointer;
-  border-radius: 4px;
-  padding: 0.5rem;
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
-  transition: 300ms;
-  align-items: center;
-
-  &:hover {
-    background: #cdcdcd20;
-  }
+  font-size: 1.1rem;
+  margin-right: 1rem;
 `;

--- a/src/components/FAQSection/QuestionFAQ/QuestionFAQ.styles.tsx
+++ b/src/components/FAQSection/QuestionFAQ/QuestionFAQ.styles.tsx
@@ -24,7 +24,7 @@ export const QuestionContainer = styled.details`
   margin: 1rem;
   background-color: white;
 
-  box-shadow: 0px 0px 4px #cdcdcd;
+  box-shadow: 0px 0px 2px grey;
 
   &:not([open]) ${IconWrapper} {
     transform: rotate(45deg);

--- a/src/components/FAQSection/QuestionFAQ/QuestionFAQ.styles.tsx
+++ b/src/components/FAQSection/QuestionFAQ/QuestionFAQ.styles.tsx
@@ -2,7 +2,7 @@
 import { Icon } from "@/components/Icon/Icon";
 import styled from "styled-components";
 
-export const SubSectionFAQ = styled.p`
+export const SubSectionFAQ = styled.div`
   transition: 100ms;
   padding: 0.5rem 1rem 1rem;
   margin: 1rem;

--- a/src/components/FAQSection/QuestionFAQ/QuestionFAQ.styles.tsx
+++ b/src/components/FAQSection/QuestionFAQ/QuestionFAQ.styles.tsx
@@ -19,7 +19,7 @@ export const SubSectionFAQ = styled.p`
     margin: 1rem 0;
   }
 
-  strong {
+  b {
     font-weight: bold;
   }
 

--- a/src/components/FAQSection/QuestionFAQ/QuestionFAQ.styles.tsx
+++ b/src/components/FAQSection/QuestionFAQ/QuestionFAQ.styles.tsx
@@ -17,8 +17,7 @@ export const IconWrapper = styled(Icon)`
   flex-shrink: 0;
 `;
 
-export const FieldDetails = styled.details`
-  box-sizing: border-box;
+export const QuestionContainer = styled.details`
   display: flex;
   width: 100%;
   padding: 1rem 0;
@@ -32,7 +31,7 @@ export const FieldDetails = styled.details`
   }
 
   &[open] ${SubSectionFAQ} {
-    margin-top: 1rem;
+    margin-top: 0.5rem;
   }
 
   @media (min-width: 768px) {

--- a/src/components/FAQSection/QuestionFAQ/QuestionFAQ.styles.tsx
+++ b/src/components/FAQSection/QuestionFAQ/QuestionFAQ.styles.tsx
@@ -1,0 +1,63 @@
+import { Icon } from "@/components/Icon/Icon";
+import styled from "styled-components";
+
+export const SubSectionFAQ = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-left: 0.5rem;
+  transition: 100ms;
+  margin-top: 0;
+  margin-left: 0.5rem;
+`;
+
+export const IconWrapper = styled(Icon)`
+  color: ${({ theme }) => theme.colors.black};
+  transition: 100ms linear;
+  flex-shrink: 0;
+`;
+
+export const FieldDetails = styled.details`
+  box-sizing: border-box;
+  display: flex;
+  width: 100%;
+  padding: 1rem 0;
+  margin: 1rem;
+  background-color: white;
+
+  box-shadow: 0px 0px 4px #cdcdcd;
+
+  &:not([open]) ${IconWrapper} {
+    transform: rotate(45deg);
+  }
+
+  &[open] ${SubSectionFAQ} {
+    margin-top: 1rem;
+  }
+
+  @media (min-width: 768px) {
+    width: 50%;
+  }
+`;
+
+export const Title = styled.h3`
+  word-break: break-word;
+  padding: 0.25rem;
+`;
+
+export const Summary = styled.summary`
+  display: flex;
+  justify-content: space-between;
+  font-weight: bold;
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 0.5rem;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+  transition: 300ms;
+  align-items: center;
+
+  &:hover {
+    background: #cdcdcd20;
+  }
+`;

--- a/src/components/FAQSection/QuestionFAQ/QuestionFAQ.tsx
+++ b/src/components/FAQSection/QuestionFAQ/QuestionFAQ.tsx
@@ -1,0 +1,24 @@
+import { IPublication } from "@/utils/interfaces";
+import {
+  FieldDetails,
+  IconWrapper,
+  SubSectionFAQ,
+  Summary,
+  Title,
+} from "./QuestionFAQ.styles";
+
+const QuestionFAQ = ({ data }: { data: IPublication }) => {
+  const { title, type } = data;
+
+  return (
+    <FieldDetails>
+      <Summary>
+        <Title>{type}</Title>
+        <IconWrapper id="close" size={16} stroke-width={2} />
+      </Summary>
+      <SubSectionFAQ>{title}</SubSectionFAQ>
+    </FieldDetails>
+  );
+};
+
+export default QuestionFAQ;

--- a/src/components/FAQSection/QuestionFAQ/QuestionFAQ.tsx
+++ b/src/components/FAQSection/QuestionFAQ/QuestionFAQ.tsx
@@ -1,6 +1,6 @@
 import { IPublication } from "@/utils/interfaces";
 import {
-  FieldDetails,
+  QuestionContainer,
   IconWrapper,
   SubSectionFAQ,
   Summary,
@@ -11,13 +11,13 @@ const QuestionFAQ = ({ data }: { data: IPublication }) => {
   const { title, type } = data;
 
   return (
-    <FieldDetails>
+    <QuestionContainer>
       <Summary>
         <Title>{type}</Title>
         <IconWrapper id="close" size={16} stroke-width={2} />
       </Summary>
       <SubSectionFAQ>{title}</SubSectionFAQ>
-    </FieldDetails>
+    </QuestionContainer>
   );
 };
 

--- a/src/components/FAQSection/QuestionFAQ/QuestionFAQ.tsx
+++ b/src/components/FAQSection/QuestionFAQ/QuestionFAQ.tsx
@@ -1,4 +1,5 @@
-import { IPublication } from "@/utils/interfaces";
+import { IFAQ } from "@/utils/interfaces";
+import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
 import {
   QuestionContainer,
   IconWrapper,
@@ -7,16 +8,14 @@ import {
   Title,
 } from "./QuestionFAQ.styles";
 
-const QuestionFAQ = ({ data }: { data: IPublication }) => {
-  const { title, type } = data;
-
+const QuestionFAQ = ({ data }: { data: IFAQ }) => {
   return (
     <QuestionContainer>
       <Summary>
-        <Title>{type}</Title>
+        <Title>{data.title}</Title>
         <IconWrapper id="close" size={16} stroke-width={2} />
       </Summary>
-      <SubSectionFAQ>{title}</SubSectionFAQ>
+      <SubSectionFAQ>{documentToReactComponents(data.details)}</SubSectionFAQ>
     </QuestionContainer>
   );
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -42,6 +42,10 @@ export const sections: ISections = {
         name: "Parceiros",
         path: "/#sponsors",
       },
+      FAQ: {
+        name: "Perguntas frequentes",
+        path: "/#FAQ",
+      },
     },
   },
   about: {

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -1,3 +1,5 @@
+import { Document } from "@contentful/rich-text-types";
+
 export interface ISponsor {
   name: string;
   logo:
@@ -155,6 +157,6 @@ export interface ISectionHeader {
 }
 
 export interface IFAQ {
-  question: string;
-  answer: string;
+  title: string;
+  details: Document;
 }

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -153,3 +153,8 @@ export interface ISectionHeader {
     subtitle?: string;
   };
 }
+
+export interface IFAQ {
+  question: string;
+  answer: string;
+}


### PR DESCRIPTION
This PR implements the 'Perguntas frequentes' section on the homepage

### How can i test it?

The section is located at the very bottom of the homepage. Note that the data being displayed is from 'Publicações do observatorio', this was just so i could learn how to use the Contentful data. **It’s not the final version** and will be replaced when we have the correct data

Please test if the layout works correctly. If you want, you can change the displayed text by modifying the 'type' or 'title' in this component: 

![image](https://github.com/user-attachments/assets/b2ef64a2-f107-4bb7-b79e-ba9bfb137ab7)
