### PR TITLE
Fix map page spacing issue on Safari

### DIFF
--- a/src/components/MapLegend/MapLegend.styles.tsx
+++ b/src/components/MapLegend/MapLegend.styles.tsx
@@ -4,7 +4,7 @@ import { Icon } from "../Icon/Icon";
 export const SubtractImage = styled(Icon)`
   transition: 0.3s;
   width: 0.75rem;
-  height: fit-content;
+  height: 100%;
 `;
 
 export const Wrapper = styled.details`

--- a/src/components/VisuItem/VisuItem.styles.tsx
+++ b/src/components/VisuItem/VisuItem.styles.tsx
@@ -97,7 +97,7 @@ export const InfoContainer = styled.div`
 
 export const QuestionMarkIcon = styled(Icon)`
   max-width: 1rem;
-  height: fit-content;
+  height: 100%;
   transition: 300ms;
   cursor: pointer;
 


### PR DESCRIPTION
## Description

This PR fixes two layout issues on Safari #156

1. Map menu items spacing issue:
<img width="632" height="892" alt="image" src="https://github.com/user-attachments/assets/250ac492-d552-4ff1-b07b-a4323172d063" />


2. Map legend spacing issue:
<img width="680" height="782" alt="image" src="https://github.com/user-attachments/assets/061014a4-ca88-4d00-9b24-3c4328ccbf10" />


## How to test it

1. Run the project locally.
2. Open the application on **Safari**.
3. Navigate to a map page category (such as "Cisternas").
4. Verify if the menu items and legend UI spacing are correct.
5. Reduce or increase your Safari window width to ensure the layout remains the same.